### PR TITLE
Change jquery version of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "author": "muyuu",
   "license": "MIT",
   "dependencies": {
-    "jquery": "^1.11.1"
+    "jquery": ">=1.11.1"
   }
 }


### PR DESCRIPTION
こんにちは!

bellows は、私の環境で試したところ、jQuery 1.x だけではなく、jQuery 2.x, 3.x でも利用可能に見えるので、package.json の dependencies の jquery を 1.11.1 以上に変更してみました。

jQuery 1.x, 2.x は、公にサポート終了を[明言](https://github.com/jquery/jquery.com/issues/162)しているので、3.x でも bellows が利用できるなら、dependencies の jquery をより新しいバージョンにしたほうが良いと思います。